### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^7.2.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-scripts": "3.3.0"
+    "react-scripts": "^3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Old version of react-scripts can cause `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined` , update to ` ^3.4.1 ` to fix.